### PR TITLE
feat: add Sentry SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,17 @@ GOOGLE_CLIENT_SECRET=
 
 # API
 API_ENDPOINT=http://127.0.0.1:8000/api/v1
+
+# Sentry
+SENTRY_DSN=
+SENTRY_ENV=local
+
+# Sentry Cli
+SENTRY_URL=
+SENTRY_ORG=
+SENTRY_PROJECT=
+SENTRY_AUTH_TOKEN=
+
+# Can get secret from here : https://generate-secret.vercel.app/64
+SECRET=
+NEXTAUTH_URL=https://leetcode-judge.ntub.edu.tw/

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@ MAKEFLAGS += --no-builtin-rules
 include .env
 $(eval export $(shell sed -ne 's/ *#.*$$//; /./ s/=.*$$// p' .env))
 
-SECRET := $(shell curl https://generate-secret.vercel.app/64)
-
 COMMA := ,
 
 PROJECT_NAME := $(shell echo $(notdir $(CURDIR)) | sed -e 's/_/-/g')
@@ -28,6 +26,14 @@ build: Dockerfile  ## Build docker image
 
 genconfig: 
 	sed -e 's#<API_ENDPOINT>#$(API_ENDPOINT)#g' \
+		-e 's#<SENTRY_DSN>#$(SENTRY_DSN)#g' \
+		-e 's#<SENTRY_ENV>#$(SENTRY_ENV)#g' \
+		-e 's#<NEXTAUTH_URL>#$(NEXTAUTH_URL)#g' \
+		-e 's#<SENTRY_URL>#$(SENTRY_URL)#g' \
+		-e 's#<SENTRY_ORG>#$(SENTRY_ORG)#g' \
+		-e 's#<SENTRY_PROJECT>#$(SENTRY_PROJECT)#g' \
+		-e 's#<SENTRY_AUTH_TOKEN>#$(SENTRY_AUTH_TOKEN)#g' \
+		-e 's#<SENTRY_RELEASE>#$(CURRENT_BRANCH)@$(CURRENT_VERSION)#g' \
 		-e 's/<GOOGLE_CLIENT_ID>/$(GOOGLE_CLIENT_ID)/g' \
 		-e 's/<GOOGLE_CLIENT_SECRET>/$(GOOGLE_CLIENT_SECRET)/g' \
 		-e 's/<SECRET>/$(SECRET)/g' \

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ $ cp .env.example .env
 $ vim .env
 $ make genconfig
 
-$ docker build -t nextjs-docker .
-$ docker run -p 3000:3000 nextjs-docker
+$ make build
+$ docker run -p 3000:3000 10446005/leetcode-judge-frontend:master
 ```

--- a/next.config.js.example
+++ b/next.config.js.example
@@ -1,4 +1,5 @@
 /** @type {import('next').NextConfig} */
+const { withSentryConfig } = require("@sentry/nextjs");
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
@@ -6,8 +7,15 @@ const nextConfig = {
     GOOGLE_CLIENT_ID: '<GOOGLE_CLIENT_ID>',
     GOOGLE_CLIENT_SECRET: '<GOOGLE_CLIENT_SECRET>',
     V1_API_ENDPOINT: '<API_ENDPOINT>',
-    SECRET: '<SECRET>', // can get secret from here : https://generate-secret.vercel.app/64
-    NEXTAUTH_URL: 'https://leetcode-judge.ntub.edu.tw/'
+    SECRET: '<SECRET>',
+    NEXTAUTH_URL: '<NEXTAUTH_URL>',
+    SENTRY_DSN: '<SENTRY_DSN>',
+    SENTRY_ENV: '<SENTRY_ENV>',
+    SENTRY_URL: '<SENTRY_URL>',
+    SENTRY_ORG: '<SENTRY_ORG>',
+    SENTRY_PROJECT: '<SENTRY_PROJECT>',
+    SENTRY_AUTH_TOKEN: '<SENTRY_AUTH_TOKEN>',
+    SENTRY_RELEASE: '<SENTRY_RELEASE>'
   },
   typescript: {
     ignoreBuildErrors: true,
@@ -16,6 +24,17 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   output: 'standalone',
-}
+};
 
-module.exports = nextConfig
+const sentryWebpackPluginOptions = {
+  // Additional config options for the Sentry Webpack plugin. Keep in mind that
+  // the following options are set automatically, and overriding them is not
+  // recommended:
+  //   release, url, org, project, authToken, configFile, stripPrefix,
+  //   urlPrefix, include, ignore
+  include: '.',
+  ignoreFile: '.sentrycliignore',
+  ignore: ['node_modules', 'webpack.config.js'],
+};
+
+module.exports = withSentryConfig(nextConfig, sentryWebpackPluginOptions);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@sentry/nextjs": "^7.12.0",
+    "@sentry/nextjs": "^7.12.1",
     "autoprefixer": "^10.4.8",
     "next": "12.2.3",
     "next-auth": "^4.10.3",

--- a/pages/api/sentry.ts
+++ b/pages/api/sentry.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+import { withSentry } from "@sentry/nextjs";
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  res.status(200).json({ name: "Hello Sentry." });
+};
+
+export default withSentry(handler);

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,0 +1,15 @@
+import * as Sentry from "@sentry/nextjs";
+
+const SENTRY_DSN: string = process.env.SENTRY_DSN || "";
+const SENTRY_RELEASE: string = process.env.SENTRY_RELEASE || "";
+const SENTRY_ENV: string = process.env.SENTRY_ENV || "local";
+
+
+if (SENTRY_DSN) {
+    Sentry.init({
+        dsn: SENTRY_DSN,
+        tracesSampleRate: 0.25,
+        release: SENTRY_RELEASE,
+        environment: SENTRY_ENV,
+      });
+}

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,0 +1,15 @@
+import * as Sentry from "@sentry/nextjs";
+
+const SENTRY_DSN: string = process.env.SENTRY_DSN || "";
+const SENTRY_RELEASE: string = process.env.SENTRY_RELEASE || "";
+const SENTRY_ENV: string = process.env.SENTRY_ENV || "local";
+
+
+if (SENTRY_DSN) {
+    Sentry.init({
+        dsn: SENTRY_DSN,
+        tracesSampleRate: 0.25,
+        release: SENTRY_RELEASE,
+        environment: SENTRY_ENV,
+      });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -685,14 +685,14 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz#0c8b74c50f29ee44f423f7416829c0bf8bb5eb27"
   integrity sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==
 
-"@sentry/browser@7.12.0":
-  version "7.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.12.0.tgz#340151eb83b41a6c54fc91a75285f99e62a843a5"
-  integrity sha512-VoqZj3wJm5aUIDG+7LjeSHIw9/pujrUlA1QMu2YOY3LaP6UQsAAsOSo52brnaQQcwBrRySksaaaTxg6obJwInw==
+"@sentry/browser@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.12.1.tgz#2be6fa5c2529a2a75abac4d00aca786362302a1a"
+  integrity sha512-pgyL65CrGFLe8sKcEG8KXAuVTE8zkAsyTlv/AuME06cSdxzO/memPK/r3BI6EM7WupIdga+V5tQUldeT1kgHNA==
   dependencies:
-    "@sentry/core" "7.12.0"
-    "@sentry/types" "7.12.0"
-    "@sentry/utils" "7.12.0"
+    "@sentry/core" "7.12.1"
+    "@sentry/types" "7.12.1"
+    "@sentry/utils" "7.12.1"
     tslib "^1.9.3"
 
 "@sentry/cli@^1.74.4":
@@ -708,102 +708,102 @@
     proxy-from-env "^1.1.0"
     which "^2.0.2"
 
-"@sentry/core@7.12.0":
-  version "7.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.12.0.tgz#14e75263b9c645ba5f314bb036d5cd1ac5aa621e"
-  integrity sha512-ERkeB/XdThvdSVZH4XysMPyWRG653HDq0AkJh8SgapExCZbwgj1lutCIpT1LIbZ8lUhRx5P+ua9OR2qj+vo5RA==
+"@sentry/core@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.12.1.tgz#a22f1c530ed528a699ed204c36eb5fc8d308103d"
+  integrity sha512-DFHbzHFjukhlkRZ5xzfebx0IBzblW43kmfnalBBq7xEMscUvnhsYnlvL9Y20tuPZ/PrTcq4JAHbFluAvw6M0QQ==
   dependencies:
-    "@sentry/hub" "7.12.0"
-    "@sentry/types" "7.12.0"
-    "@sentry/utils" "7.12.0"
+    "@sentry/hub" "7.12.1"
+    "@sentry/types" "7.12.1"
+    "@sentry/utils" "7.12.1"
     tslib "^1.9.3"
 
-"@sentry/hub@7.12.0":
-  version "7.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.12.0.tgz#b30d04222fd4e1a920ace8482de3aa413e04ca43"
-  integrity sha512-UgpC9WiHQAfcoEIIgeIopp3jeabllK6beLl5vA4ei6ay2TDMjA4NqUpzGq/GWVG0ewnblvHkqmjwAls2AEMtWg==
+"@sentry/hub@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.12.1.tgz#dffad40cd2b8f44df2d5f20a89df87879cbbf1c3"
+  integrity sha512-KLVnVqXf+CRmXNy9/T8K2/js7QvOQ94xtgP5KnWJbu2rl+JhxnIGiBRF51lPXFIatt7zWwB9qNdMS8lVsvLMGQ==
   dependencies:
-    "@sentry/types" "7.12.0"
-    "@sentry/utils" "7.12.0"
+    "@sentry/types" "7.12.1"
+    "@sentry/utils" "7.12.1"
     tslib "^1.9.3"
 
-"@sentry/integrations@7.12.0":
-  version "7.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.12.0.tgz#25fb13012807ea95b7adb482b327c83d4f46a4b3"
-  integrity sha512-eCmabzoUsHDsboh3ensf9KRUdvmJo4pH4D0iQMaKN8nEM2CMq1K1vTu7YNM64W9xR8cvSolo/1RpNAAVvvccWg==
+"@sentry/integrations@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.12.1.tgz#da1dbc5d851f2fc9413883812c436a1540a5b27a"
+  integrity sha512-35iW3WZ6rnUzjf6kWS5604xtPCtIb4gESoDKIKPKw2q7gI+qA5Ad/Q5yM50cDwoR3uOhXZ4tv3WB2/16wSGWFg==
   dependencies:
-    "@sentry/types" "7.12.0"
-    "@sentry/utils" "7.12.0"
+    "@sentry/types" "7.12.1"
+    "@sentry/utils" "7.12.1"
     localforage "^1.8.1"
     tslib "^1.9.3"
 
-"@sentry/nextjs@^7.12.0":
-  version "7.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/nextjs/-/nextjs-7.12.0.tgz#4b0a514cf1cc5b0ea912dd2e5a27164791fb8e19"
-  integrity sha512-jJ32zbDtW1JCuHol9GQKkSS1IPYwvahBVc7cJkAnyIPJlYBl7dlRKvd1ojjfCBkHJFs1NVRxtXHBqKSZ5SKVZw==
+"@sentry/nextjs@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/nextjs/-/nextjs-7.12.1.tgz#c34d4237d0914cc6bdde9e0238da6a16e51c3463"
+  integrity sha512-g9Aw+x+H8ihND1vO01ee0E77tnwZO4FhnVCYv8LHUNwR+PMrV8UeRirIeqlXjAl696lcg9In42wufHxd65KNGA==
   dependencies:
     "@babel/parser" "^7.18.10"
     "@rollup/plugin-sucrase" "4.0.4"
-    "@sentry/core" "7.12.0"
-    "@sentry/hub" "7.12.0"
-    "@sentry/integrations" "7.12.0"
-    "@sentry/node" "7.12.0"
-    "@sentry/react" "7.12.0"
-    "@sentry/tracing" "7.12.0"
-    "@sentry/types" "7.12.0"
-    "@sentry/utils" "7.12.0"
+    "@sentry/core" "7.12.1"
+    "@sentry/hub" "7.12.1"
+    "@sentry/integrations" "7.12.1"
+    "@sentry/node" "7.12.1"
+    "@sentry/react" "7.12.1"
+    "@sentry/tracing" "7.12.1"
+    "@sentry/types" "7.12.1"
+    "@sentry/utils" "7.12.1"
     "@sentry/webpack-plugin" "1.19.0"
     chalk "3.0.0"
     jscodeshift "^0.13.1"
     rollup "2.78.0"
     tslib "^1.9.3"
 
-"@sentry/node@7.12.0":
-  version "7.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.12.0.tgz#c4de36926877bec9f8f351db58f34b8a6f292d7e"
-  integrity sha512-N3Ja/lHb8rf0pFwgsRKW7yUB2p0lOVGIEwCl/7w1XxqOinBMT6L1W/OcLNOHjBKxMfk6LRhaqHe+vpZr4FbIPw==
+"@sentry/node@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.12.1.tgz#ced12d0db3ca5715d699858acb1e2f2ea1d7c59b"
+  integrity sha512-ZVT2+lLd3gbhOuCOczlFLHH2KnD4EXrq6jRp5Sb2vsSZGVHnVsbD5j7i54zbSBqcydlFqzVMqWSysGTKoYiimw==
   dependencies:
-    "@sentry/core" "7.12.0"
-    "@sentry/hub" "7.12.0"
-    "@sentry/types" "7.12.0"
-    "@sentry/utils" "7.12.0"
+    "@sentry/core" "7.12.1"
+    "@sentry/hub" "7.12.1"
+    "@sentry/types" "7.12.1"
+    "@sentry/utils" "7.12.1"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/react@7.12.0":
-  version "7.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.12.0.tgz#b4e2cceee44f86a17581e7f8310f6cd70041e7f0"
-  integrity sha512-ESWDE0JGTF57ax+NHkQwHStRHR2pR2IiOkwYTHTFfKkltyLZHkJZMBX3oLMRwU7pgS5LKTtVYAoPDndWfIJGqg==
+"@sentry/react@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.12.1.tgz#075162d39ea05c58217597d5242f7046c3152ea9"
+  integrity sha512-CmdiRzhPpjD29GxlDJs+VIoLlQcKp1BfISQOfPUZNppWbKyRad+J5Z8tgg5MCNPHjQtcOT+0V+MsSdRNqtXg4g==
   dependencies:
-    "@sentry/browser" "7.12.0"
-    "@sentry/types" "7.12.0"
-    "@sentry/utils" "7.12.0"
+    "@sentry/browser" "7.12.1"
+    "@sentry/types" "7.12.1"
+    "@sentry/utils" "7.12.1"
     hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
 
-"@sentry/tracing@7.12.0":
-  version "7.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.12.0.tgz#50fdb5aa64a211c6609ea44b7452149e26b5433d"
-  integrity sha512-TK30G/g15KplKOPncu61XvNLjaI+Kbe64UBTSTANMkidlEjiZ8N0P8L9AqUG+rUIk7YbIu11DS6edGY/LK0WEQ==
+"@sentry/tracing@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.12.1.tgz#9f92985f152054ac90b6ec83a33c44e8084a008e"
+  integrity sha512-WnweIt//IqkEkJSjA8DtnIeCdItYIqJSxNQ6qK+r546/ufxRYFBck2fbmM0oKZJVg2evbwhadrBTIUzYkqNj4A==
   dependencies:
-    "@sentry/hub" "7.12.0"
-    "@sentry/types" "7.12.0"
-    "@sentry/utils" "7.12.0"
+    "@sentry/hub" "7.12.1"
+    "@sentry/types" "7.12.1"
+    "@sentry/utils" "7.12.1"
     tslib "^1.9.3"
 
-"@sentry/types@7.12.0":
-  version "7.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.12.0.tgz#108a995c77d133f22366e6976fefa0ca7f8dcf5d"
-  integrity sha512-ldcuRzEx2ccZvaJjTSemWj+7TiWCV5A/vV7fEtZeoETFI+SiVbmqI5whdH7ZVVfhRNFf25Ib+TfTeaM9PM7A1A==
+"@sentry/types@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.12.1.tgz#eff76d938f9effc62a2ec76cd5c3f04de37f5c15"
+  integrity sha512-VGZs39SZgMcCGv7H0VyFy1LEFGsnFZH590JUopmz6nG63EpeYQ2xzhIoPNAiLKbyUvBEwukn+faCg3u3MGqhgQ==
 
-"@sentry/utils@7.12.0":
-  version "7.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.12.0.tgz#dd00bed3908f31453f2362988e501f98d534c7dd"
-  integrity sha512-GVB8E0V3RJHQClvi0gsRRJvDXP5c7M5ByYAvspJDczOOxNF8LTjTYVkBXAUdR9kcs+nya1q1YVsKvde2WGORTA==
+"@sentry/utils@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.12.1.tgz#fcf80fdc332d0bd288e21b13efc7a2f0d604f75a"
+  integrity sha512-Dh8B13pC0u8uLM/zf+oZngyg808c6BDEO94F7H+h3IciCVVd92A0cOQwLGAEdf8srnJgpZJNAlSC8lFDhbFHzQ==
   dependencies:
-    "@sentry/types" "7.12.0"
+    "@sentry/types" "7.12.1"
     tslib "^1.9.3"
 
 "@sentry/webpack-plugin@1.19.0":


### PR DESCRIPTION
1. Setup Sentry SDK env, `$ cp -r .env.example .env` and `$ vim .env`.

2. Generate `next.config.js` via `$ make genconfig`.

3. `$ yarn install`.

4. Test Sentry SDK.